### PR TITLE
Allow users to set temporary directory

### DIFF
--- a/kb_python/count.py
+++ b/kb_python/count.py
@@ -634,6 +634,8 @@ def count(
         )
     unfiltered_results.update(bus_result)
 
+    logger.info(f'Using temp dir {temp_dir}')
+
     sort_result = bustools_sort(
         bus_result['bus'],
         os.path.join(temp_dir, BUS_S_FILENAME),

--- a/kb_python/main.py
+++ b/kb_python/main.py
@@ -152,6 +152,7 @@ def parse_count(args):
             loom=args.loom,
             h5ad=args.h5ad,
             nucleus=args.workflow == 'nucleus' or args.nucleus,
+	    temp_dir=args.temp_dir
         )
     else:
         count(
@@ -168,6 +169,7 @@ def parse_count(args):
             overwrite=args.overwrite,
             loom=args.loom,
             h5ad=args.h5ad,
+	    temp_dir=args.temp_dir
         )
 
 
@@ -395,6 +397,14 @@ def setup_count_args(parser, parent):
         default='4G'
     )
     parser_count.add_argument(
+        '--tmp',
+	dest="temp_dir",
+	metavar='TMP',
+	help='temporary directory location',
+	type=str,
+	default=TEMP_DIR
+    )
+    parser_count.add_argument(
         '--tcc',
         help='Generate a TCC matrix instead of a gene count matrix.',
         action='store_true'
@@ -558,8 +568,8 @@ def main():
     logger.debug(
         'bustools binary located at {}'.format(get_bustools_binary_path())
     )
-    logger.debug('Creating tmp directory')
-    make_directory(TEMP_DIR)
+    logger.debug(f'Creating tmp directory at {args.temp_dir}')
+    make_directory(args.temp_dir)
     try:
         logger.debug(args)
         COMMAND_TO_FUNCTION[args.command](args)
@@ -570,5 +580,5 @@ def main():
     finally:
         # Always clean temp dir
         if not args.keep_tmp:
-            logger.debug('Removing tmp directory')
-            remove_directory(TEMP_DIR)
+            logger.debug(f'Removing tmp directory at {args.temp_dir}')
+            remove_directory(args.temp_dir)

--- a/kb_python/main.py
+++ b/kb_python/main.py
@@ -152,7 +152,7 @@ def parse_count(args):
             loom=args.loom,
             h5ad=args.h5ad,
             nucleus=args.workflow == 'nucleus' or args.nucleus,
-	    temp_dir=args.temp_dir
+            temp_dir=args.temp_dir
         )
     else:
         count(
@@ -169,7 +169,7 @@ def parse_count(args):
             overwrite=args.overwrite,
             loom=args.loom,
             h5ad=args.h5ad,
-	    temp_dir=args.temp_dir
+            temp_dir=args.temp_dir
         )
 
 
@@ -398,11 +398,11 @@ def setup_count_args(parser, parent):
     )
     parser_count.add_argument(
         '--tmp',
-	dest="temp_dir",
-	metavar='TMP',
-	help='temporary directory location',
-	type=str,
-	default=TEMP_DIR
+        dest="temp_dir",
+        metavar='TMP',
+        help='temporary directory location',
+        type=str,
+        default=TEMP_DIR
     )
     parser_count.add_argument(
         '--tcc',


### PR DESCRIPTION
The [introduction](https://www.kallistobus.tools/introduction) describes an option to set the temporary directory, but it looks like it's currently hard-coded as `TEMP_DIR`.  This PR should fix that issue for `kb count` by adding `temp_dir` to the `argparse` arguments.


**What is the exact command that was run?**
```bash
kb count -i $REF/transcriptome.idx \
--tmp $TMP \
-g $REF/transcripts_to_genes.txt -x 10xv2 --h5ad \
-t $CORES -m "15G" \
-o $KB_FOLD --verbose \
$(ls $FASTQ_FOLDER/*.gz)
```

```bash
usage: kb [-h] [--list] <CMD> ...
kb: error: unrecognized arguments: --tmp
```

**EDIT**: Sorry, I just saw #72. It looks like that also references the `temp_dir` but is a slightly different issue. I can rebase off of that or can help resolve the merge conflicts. Feel free to modify it as you see fit if you decide to accept this PR.