### PR TITLE
Iupac extension

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: "Close stale issues"
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        days-before-stale: 30
+        days-before-close: 5

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pre-processing of single-cell RNA-seq. BioRxiv, 673285.
 None. The kallisto and bustools binaries are included with the package.
 
 ## Getting Started
-Visit the [Getting Started](https://www.kallistobus.tools/kb_getting_started) page.
+Visit the [Getting Started](https://colab.research.google.com/github/pachterlab/kallistobustools/blob/master/notebooks/kb_standard.ipynb) tutorial on Google Colab.
 
 ## Documentation
 - User documentation and tutorials are available [here](https://www.kallistobus.tools/tutorials).

--- a/kb_python/fasta.py
+++ b/kb_python/fasta.py
@@ -18,16 +18,21 @@ class FASTA:
     """
     PARSER = re.compile(r'^>(?P<sequence_id>\S+)(?P<group>.*)')
     GROUP_PARSER = re.compile(r'(?P<key>\S+?):(?P<value>\S+)')
-    BASEPAIRS = {
-        'a': 'T',
+    COMPLEMENT = {
         'A': 'T',
-        'c': 'G',
         'C': 'G',
-        'g': 'C',
         'G': 'C',
-        't': 'A',
         'T': 'A',
-        'n': 'N',
+        'Y': 'R',
+        'R': 'Y',
+        'W': 'W',
+        'S': 'S',
+        'K': 'M',
+        'M': 'K',
+        'D': 'H',
+        'V': 'B',
+        'H': 'D',
+        'B': 'V',
         'N': 'N',
     }
 
@@ -81,7 +86,7 @@ class FASTA:
         :return: reverse complement
         :rtype: str
         """
-        return ''.join(FASTA.BASEPAIRS[b] for b in reversed(sequence))
+        return ''.join(FASTA.COMPLEMENT[b.upper()] for b in reversed(sequence))
 
     def entries(self):
         """Generator that yields one FASTA entry (sequence ID + sequence) at a time.

--- a/kb_python/fasta.py
+++ b/kb_python/fasta.py
@@ -86,7 +86,7 @@ class FASTA:
         :return: reverse complement
         :rtype: str
         """
-        return ''.join(FASTA.COMPLEMENT[b.upper()] for b in reversed(sequence))
+        return ''.join(FASTA.COMPLEMENT[b] for b in reversed(sequence.upper()))
 
     def entries(self):
         """Generator that yields one FASTA entry (sequence ID + sequence) at a time.

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -195,3 +195,9 @@ class TestFASTA(TestMixin, TestCase):
         fasta.generate_unspliced_fasta(
             self.sorted_fasta_path, self.sorted_gtf_path, out_path
         )
+
+    def test_complement(self):
+        # check for each code and its complement,
+        # if the complement's complement is the code.
+        for key, value in fasta.FASTA.COMPLEMENT.items():
+            assert key == fasta.FASTA.COMPLEMENT[value]


### PR DESCRIPTION
I downloaded genome GRCh38 through genomepy:

```
genome url: https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.26_GRCh38/GCF_000001405.26_GRCh38_genomic.fna.gz
annotation url: https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.26_GRCh38/GCF_000001405.26_GRCh38_genomic.gff.gz
```

When I run kb ref on this I get the error that R is not in BASEPAIRS.

I updated (and renamed) BASEPAIRS/COMPLEMENT to allow all IUPAC codes. My guess would be that kallisto can just work with this right? I'll make sure to test this.

complement cheatsheet I used:

http://arep.med.harvard.edu/labgc/adnan/projects/Utilities/revcomp.html