### PR TITLE
merge devel into master

### DIFF
--- a/kb_python/ref.py
+++ b/kb_python/ref.py
@@ -405,9 +405,7 @@ def ref(
             cdnas.append(cdna_temp_path)
 
         logger.info(f'Concatenating {len(cdnas)} cDNAs to {cdna_path}')
-        cdna_path = concatenate_files(
-            *cdnas, out_path=cdna_path, temp_dir=temp_dir
-        )
+        cdna_path = concatenate_files(*cdnas, out_path=cdna_path)
         results.update({'cdna_fasta': cdna_path})
     else:
         logger.info(
@@ -614,26 +612,20 @@ def ref_lamanno(
 
         # Concatenate
         logger.info(f'Concatenating {len(cdnas)} cDNA FASTAs to {cdna_path}')
-        cdna_path = concatenate_files(
-            *cdnas, out_path=cdna_path, temp_dir=temp_dir
-        )
+        cdna_path = concatenate_files(*cdnas, out_path=cdna_path)
         logger.info(
             f'Concatenating {len(cdna_t2cs)} cDNA transcripts-to-captures to {cdna_t2c_path}'
         )
-        cdna_t2c_path = concatenate_files(
-            *cdna_t2cs, out_path=cdna_t2c_path, temp_dir=temp_dir
-        )
+        cdna_t2c_path = concatenate_files(*cdna_t2cs, out_path=cdna_t2c_path)
         logger.info(
             f'Concatenating {len(introns)} intron FASTAs to {intron_path}'
         )
-        intron_path = concatenate_files(
-            *introns, out_path=intron_path, temp_dir=temp_dir
-        )
+        intron_path = concatenate_files(*introns, out_path=intron_path)
         logger.info(
             f'Concatenating {len(intron_t2cs)} intron transcripts-to-captures to {intron_t2c_path}'
         )
         intron_t2c_path = concatenate_files(
-            *intron_t2cs, out_path=intron_t2c_path, temp_dir=temp_dir
+            *intron_t2cs, out_path=intron_t2c_path
         )
         results.update({
             'cdna_fasta': cdna_path,
@@ -652,7 +644,7 @@ def ref_lamanno(
         combined_path = get_temporary_filename(temp_dir)
         logger.info(f'Concatenating cDNA and intron FASTAs to {combined_path}')
         combined_path = concatenate_files(
-            cdna_path, intron_path, out_path=combined_path, temp_dir=temp_dir
+            cdna_path, intron_path, out_path=combined_path
         )
         t2g_result = create_t2g_from_fasta(combined_path, t2g_path)
         results.update(t2g_result)

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -298,7 +298,7 @@ class TestRef(TestMixin, TestCase):
                 transcript_infos,
             )
             concatenate_files.assert_called_once_with(
-                cdna_fasta_path, out_path=cdna_fasta_path, temp_dir=temp_dir
+                cdna_fasta_path, out_path=cdna_fasta_path
             )
             kallisto_index.assert_called_once_with(
                 cdna_fasta_path, index_path, k=31
@@ -356,7 +356,7 @@ class TestRef(TestMixin, TestCase):
                 transcript_infos,
             )
             concatenate_files.assert_called_once_with(
-                cdna_fasta_path, out_path=cdna_fasta_path, temp_dir=temp_dir
+                cdna_fasta_path, out_path=cdna_fasta_path
             )
             kallisto_index.assert_not_called()
             split_and_index.assert_called_once_with(
@@ -415,7 +415,7 @@ class TestRef(TestMixin, TestCase):
                 transcript_infos,
             )
             concatenate_files.assert_called_once_with(
-                cdna_fasta_path, out_path=cdna_fasta_path, temp_dir=temp_dir
+                cdna_fasta_path, out_path=cdna_fasta_path
             )
             kallisto_index.assert_called_once_with(
                 cdna_fasta_path, index_path, k=k
@@ -560,7 +560,7 @@ class TestRef(TestMixin, TestCase):
                 transcript_infos,
             )
             concatenate_files.assert_called_once_with(
-                cdna_fasta_path, out_path=cdna_fasta_path, temp_dir=temp_dir
+                cdna_fasta_path, out_path=cdna_fasta_path
             )
             kallisto_index.assert_called_once_with(
                 cdna_fasta_path, index_path, k=31
@@ -886,15 +886,14 @@ class TestRef(TestMixin, TestCase):
             ])
             self.assertEqual(5, concatenate_files.call_count)
             concatenate_files.assert_has_calls([
-                call('cdna', out_path=cdna_fasta_path, temp_dir=temp_dir),
-                call('cdna_t2c', out_path=cdna_t2c_path, temp_dir=temp_dir),
-                call('intron', out_path=intron_fasta_path, temp_dir=temp_dir),
-                call('intron_t2c', out_path=intron_t2c_path, temp_dir=temp_dir),
+                call('cdna', out_path=cdna_fasta_path),
+                call('cdna_t2c', out_path=cdna_t2c_path),
+                call('intron', out_path=intron_fasta_path),
+                call('intron_t2c', out_path=intron_t2c_path),
                 call(
                     cdna_fasta_path,
                     intron_fasta_path,
                     out_path='combined',
-                    temp_dir=temp_dir
                 )
             ])
             kallisto_index.assert_called_once_with(
@@ -990,15 +989,14 @@ class TestRef(TestMixin, TestCase):
             ])
             self.assertEqual(5, concatenate_files.call_count)
             concatenate_files.assert_has_calls([
-                call('cdna', out_path=cdna_fasta_path, temp_dir=temp_dir),
-                call('cdna_t2c', out_path=cdna_t2c_path, temp_dir=temp_dir),
-                call('intron', out_path=intron_fasta_path, temp_dir=temp_dir),
-                call('intron_t2c', out_path=intron_t2c_path, temp_dir=temp_dir),
+                call('cdna', out_path=cdna_fasta_path),
+                call('cdna_t2c', out_path=cdna_t2c_path),
+                call('intron', out_path=intron_fasta_path),
+                call('intron_t2c', out_path=intron_t2c_path),
                 call(
                     cdna_fasta_path,
                     intron_fasta_path,
                     out_path='combined',
-                    temp_dir=temp_dir
                 )
             ])
             self.assertEqual(2, kallisto_index.call_count)
@@ -1095,15 +1093,14 @@ class TestRef(TestMixin, TestCase):
             ])
             self.assertEqual(5, concatenate_files.call_count)
             concatenate_files.assert_has_calls([
-                call('cdna', out_path=cdna_fasta_path, temp_dir=temp_dir),
-                call('cdna_t2c', out_path=cdna_t2c_path, temp_dir=temp_dir),
-                call('intron', out_path=intron_fasta_path, temp_dir=temp_dir),
-                call('intron_t2c', out_path=intron_t2c_path, temp_dir=temp_dir),
+                call('cdna', out_path=cdna_fasta_path),
+                call('cdna_t2c', out_path=cdna_t2c_path),
+                call('intron', out_path=intron_fasta_path),
+                call('intron_t2c', out_path=intron_t2c_path),
                 call(
                     cdna_fasta_path,
                     intron_fasta_path,
                     out_path='combined',
-                    temp_dir=temp_dir
                 )
             ])
             kallisto_index.assert_called_once_with(
@@ -1198,15 +1195,14 @@ class TestRef(TestMixin, TestCase):
             ])
             self.assertEqual(5, concatenate_files.call_count)
             concatenate_files.assert_has_calls([
-                call('cdna', out_path=cdna_fasta_path, temp_dir=temp_dir),
-                call('cdna_t2c', out_path=cdna_t2c_path, temp_dir=temp_dir),
-                call('intron', out_path=intron_fasta_path, temp_dir=temp_dir),
-                call('intron_t2c', out_path=intron_t2c_path, temp_dir=temp_dir),
+                call('cdna', out_path=cdna_fasta_path),
+                call('cdna_t2c', out_path=cdna_t2c_path),
+                call('intron', out_path=intron_fasta_path),
+                call('intron_t2c', out_path=intron_t2c_path),
                 call(
                     cdna_fasta_path,
                     intron_fasta_path,
                     out_path='combined',
-                    temp_dir=temp_dir
                 )
             ])
             kallisto_index.assert_called_once_with(
@@ -1276,7 +1272,6 @@ class TestRef(TestMixin, TestCase):
                 cdna_fasta_path,
                 intron_fasta_path,
                 out_path='combined',
-                temp_dir=temp_dir
             )
             kallisto_index.assert_called_once_with(
                 combined_path, index_path, k=31
@@ -1424,15 +1419,14 @@ class TestRef(TestMixin, TestCase):
             ])
             self.assertEqual(5, concatenate_files.call_count)
             concatenate_files.assert_has_calls([
-                call('cdna', out_path=cdna_fasta_path, temp_dir=temp_dir),
-                call('cdna_t2c', out_path=cdna_t2c_path, temp_dir=temp_dir),
-                call('intron', out_path=intron_fasta_path, temp_dir=temp_dir),
-                call('intron_t2c', out_path=intron_t2c_path, temp_dir=temp_dir),
+                call('cdna', out_path=cdna_fasta_path),
+                call('cdna_t2c', out_path=cdna_t2c_path),
+                call('intron', out_path=intron_fasta_path),
+                call('intron_t2c', out_path=intron_t2c_path),
                 call(
                     cdna_fasta_path,
                     intron_fasta_path,
                     out_path='combined',
-                    temp_dir=temp_dir
                 )
             ])
             kallisto_index.assert_called_once_with(


### PR DESCRIPTION
### `ref`
* Fixed an issue with a dangling keyword argument when concatenating files.

### `count`
* Fixed an issue where using `-x smartseq` would check for the `--nucleus` flag, which was deprecated in the previous version.