### PR TITLE
upgrade ngs_tools to 1.5.14 for BDWTA whitelist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Jinja2>2.10.1
 loompy>=3.0.6
 nbconvert>=5.6.0
 nbformat>=4.4.0
-ngs-tools>=1.5.13
+ngs-tools>=1.5.14
 numpy>=1.17.2
 pandas>=1.0.0
 plotly>=4.5.0


### PR DESCRIPTION
### `count`
* Whitelist for technology `-x BDWTA` is now provided.