### PR TITLE
Remove np.matrix dependency

### DIFF
--- a/kb_python/report/report_matrix.ipynb
+++ b/kb_python/report/report_matrix.ipynb
@@ -158,7 +158,7 @@
     "sc.pp.normalize_total(adata, target_sum=1e4)\n",
     "sc.pp.log1p(adata)\n",
     "pca = PCA(n_components=10)\n",
-    "pc = pca.fit_transform(adata.X.todense())"
+    "pc = pca.fit_transform(adata.X.toarray())"
    ]
   },
   {

--- a/kb_python/report/report_matrix.ipynb
+++ b/kb_python/report/report_matrix.ipynb
@@ -158,7 +158,7 @@
     "sc.pp.normalize_total(adata, target_sum=1e4)\n",
     "sc.pp.log1p(adata)\n",
     "pca = PCA(n_components=10)\n",
-    "pc = pca.fit_transform(adata.X.toarray())"
+    "pc = pca.fit_transform(adata.X.todense())"
    ]
   },
   {


### PR DESCRIPTION
As most of us may know, `numpy` is slowly deprecating the `np.matrix` class. However, the package still has one dependency on this class in `report_matrix.ipynb`, and `scikit-learn` is also in the process of doing it (see scikit-learn/scikit-learn#20165). This PR causes the `pca.fit_transform`'s input to switch from `np.matrix` (the output of `csr_matrix.todense()`) to `np.ndarray` (the output of csr_matrix.toarray()`)

However, it must be noted that `pca.fit_transform()` may have slightly different results depending on its input being `np.matrix` or `np.ndarray`, see scikit-learn/scikit-learn#18941. I guess the difference is small enough to matter, but I guess you may think about it a bit.

This is my first PR in the past 5 years, so bear with me.